### PR TITLE
Add support for cancellation token.

### DIFF
--- a/AxisPlayer.Core/ViewModels/PlayerViewModel.cs
+++ b/AxisPlayer.Core/ViewModels/PlayerViewModel.cs
@@ -42,7 +42,7 @@ namespace AxisPlayer.ViewModels
             Debug.WriteLine($"Update source: {uri}");
 
             Frame = null;
-            _decoder.StartDecodingAsync(uri);
+            _decoder.StartDecodingAsync(uri, default);
         }
     }
 }

--- a/AxisPlayer.Tests/ViewModels/MainViewModelTests.cs
+++ b/AxisPlayer.Tests/ViewModels/MainViewModelTests.cs
@@ -32,7 +32,7 @@ namespace AxisPlayer.ViewModels.Tests
             SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
 
             var decoderStub = new Mock<IStreamDecoder>();
-            decoderStub.Setup(x => x.StartDecodingAsync(It.IsAny<string>()));
+            decoderStub.Setup(x => x.StartDecodingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()));
                 //.Callback((string x) => Debug.Print($"---->{x}"));
 
             Locator.CurrentMutable.Register(() => decoderStub.Object); 

--- a/AxisPlayer.Tests/ViewModels/PlayerViewModelTests.cs
+++ b/AxisPlayer.Tests/ViewModels/PlayerViewModelTests.cs
@@ -22,7 +22,7 @@ namespace AxisPlayer.ViewModels.Tests
             string actual = null;
 
             var stub = new Mock<IStreamDecoder>();
-            stub.Setup(x => x.StartDecodingAsync(It.IsAny<string>()))
+            stub.Setup(x => x.StartDecodingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Callback((string x) => actual = x);
 
             PlayerViewModel vm = new PlayerViewModel(stub.Object);

--- a/FrameSaver/Program.cs
+++ b/FrameSaver/Program.cs
@@ -22,11 +22,13 @@ namespace FrameSaver
             }
 
             var decoder = new StreamDecoder();
-        
-            decoder.OnFrameReceived += Decoder_OnFrameReceived; 
-            decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg");
 
-            Console.ReadLine();
+            var tokenSource = new CancellationTokenSource();
+            tokenSource.CancelAfter(5000);
+            decoder.OnFrameReceived += Decoder_OnFrameReceived;
+            decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg", tokenSource.Token);
+
+            while (!tokenSource.Token.IsCancellationRequested) { }
 
             //while (true)
             //{

--- a/MJPEG.Tests/StreamDecoderTests.cs
+++ b/MJPEG.Tests/StreamDecoderTests.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.IO;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace MJPEG.Tests
 {
@@ -56,13 +57,13 @@ namespace MJPEG.Tests
         }
 
         [TestMethod]
-        public void GetContentTest()
+        public async Task GetContentTest()
         {
             byte[] buf = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
             using MemoryStream ms = new MemoryStream(buf);
 
-            byte[] act = _decoder.GetContent(ms, 3);
+            byte[] act = await _decoder.GetContent(ms, 3);
 
             Assert.IsNotNull(act);
             Assert.AreEqual(3, act.Length);

--- a/MJPEG/IStreamDecoder.cs
+++ b/MJPEG/IStreamDecoder.cs
@@ -1,9 +1,11 @@
-﻿namespace MJPEG
+﻿using System.Threading;
+
+namespace MJPEG
 {
     public interface IStreamDecoder
     {
         event StreamDecoder.FrameHandler OnFrameReceived;
 
-        void StartDecodingAsync(string uri);
+        void StartDecodingAsync(string uri, CancellationToken token);
     }
 }

--- a/SimplePlayer/MainWindow.xaml.cs
+++ b/SimplePlayer/MainWindow.xaml.cs
@@ -26,7 +26,7 @@ namespace SimplePlayer
         private BackgroundWorker _worker = new BackgroundWorker();
 
         private StreamDecoder _decoder = new StreamDecoder();
-        
+
         public MainWindow()
         {
             InitializeComponent();
@@ -34,7 +34,7 @@ namespace SimplePlayer
 
         private void Window_Initialized(object sender, EventArgs e)
         {
-            _decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg");
+            _decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg", default);
             _decoder.OnFrameReceived += _decoder_OnFrameReceived;
 
             // Not used anymore

--- a/SimplePlayerIoC/ISimpleService.cs
+++ b/SimplePlayerIoC/ISimpleService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace SimplePlayerIoC
 {
@@ -8,6 +9,6 @@ namespace SimplePlayerIoC
     {
         byte[] GetLastFrame();
 
-        void StartDecoding();
+        void StartDecoding(CancellationToken token);
     }
 }

--- a/SimplePlayerIoC/MainWindow.xaml.cs
+++ b/SimplePlayerIoC/MainWindow.xaml.cs
@@ -54,7 +54,7 @@ namespace SimplePlayerIoC
 
         private void startButton_Click(object sender, RoutedEventArgs e)
         {
-            _simpleService.StartDecoding();
+            _simpleService.StartDecoding(default);
 
             startButton.Visibility = Visibility.Hidden;
         }

--- a/SimplePlayerIoC/SimpleService.cs
+++ b/SimplePlayerIoC/SimpleService.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
 
 namespace SimplePlayerIoC
 {
@@ -16,6 +17,6 @@ namespace SimplePlayerIoC
 
         public byte[] GetLastFrame() => _decoder.GetLastFrame();
 
-        public void StartDecoding() => _decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg");
+        public void StartDecoding(CancellationToken token) => _decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg",token);
     }
 }


### PR DESCRIPTION
Here is my pull request for issue #1, adding support for cancellation tokens.

Example
```
            var tokenSource = new CancellationTokenSource();
            tokenSource.CancelAfter(5000);
            decoder.OnFrameReceived += Decoder_OnFrameReceived;
            decoder.StartDecodingAsync("http://83.128.74.78:8083/mjpg/video.mjpg", tokenSource.Token);
```



I hope you find it useful.